### PR TITLE
refactor(config): simplify migration service dependency injection

### DIFF
--- a/src/modules/config/index.ts
+++ b/src/modules/config/index.ts
@@ -8,4 +8,6 @@ export { type IConfigGetOptions, type IConfigSetOptions } from "./interface";
 export type * from "./interface";
 export { EConfigMigrationStatus } from "./migration";
 export type * from "./migration";
+export { ConfigMigrationRunnerService } from "./migration/migration-runner.service";
+export { ConfigMigrationService } from "./migration/migration.service";
 export type * from "./type";

--- a/test/unit/modules/config/migration/migration.service.test.ts
+++ b/test/unit/modules/config/migration/migration.service.test.ts
@@ -79,12 +79,24 @@ describe("ConfigMigrationService", () => {
    },
   };
 
-  service = new ConfigMigrationService(mockDataSource, mockOptions, mockConfigService);
+  service = new ConfigMigrationService(
+   mockDataSource,
+   mockOptions,
+   mockConfigService,
+   mockMigrationService,
+  );
 
-  // Mock the private migrationService
-  (service as any).migrationService = mockMigrationService;
+  // Mock onModuleInit - it should be a no-op in our tests
+  service.onModuleInit();
 
   // Mock logger
+  const mockLogger: Logger = {
+   log: vi.fn(),
+   error: vi.fn(),
+   warn: vi.fn(),
+   debug: vi.fn(),
+   verbose: vi.fn(),
+  } as any;
   vi.spyOn(service["LOGGER"], "verbose").mockImplementation(() => {});
   vi.spyOn(service["LOGGER"], "warn").mockImplementation(() => {});
   vi.spyOn(service["LOGGER"], "error").mockImplementation(() => {});


### PR DESCRIPTION
Refactored ConfigMigrationService to use constructor injection for migration service dependency instead of creating dynamic service. Exported ConfigMigrationRunnerService and ConfigMigrationService from config module index. Updated tests to reflect the new dependency injection pattern.