### PR TITLE
fix(deps): pin compatible nest swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "@nestjs/passport": "^11.0.5",
   "@nestjs/platform-fastify": "^11.1.24",
   "@nestjs/schematics": "^11.1.0",
-  "@nestjs/swagger": "^11.4.2",
+  "@nestjs/swagger": "11.4.2",
   "@nestjs/testing": "^11.1.24",
   "@nestjs/throttler": "^6.5.0",
   "@nestjs/typeorm": "^11.0.1",


### PR DESCRIPTION
## Summary
- Pins `@nestjs/swagger` to `11.4.2` without a caret so CI does not resolve `11.4.4`.
- Matches the version used by `@elsikora/nestjs-crud-automator@2.8.0` to avoid the blocked `./dist/constants.js` deep import.

## Test plan
- `npm run test:unit`