### PR TITLE
build(rollup): generate declarations with unplugin dts

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   "prettier": "^3.8.3",
   "rimraf": "^6.1.3",
   "rollup": "^4.61.1",
-  "rollup-plugin-dts-path-alias": "^0.0.3",
   "rollup-plugin-generate-package-json": "^3.2.0",
   "rxjs": "^7.8.2",
   "semantic-release": "^25.0.3",
@@ -112,6 +111,7 @@
   "tslib": "^2.8.1",
   "typeorm": "^1.0.0",
   "typescript": "^6.0.3",
+  "unplugin-dts": "^1.0.2",
   "vite-tsconfig-paths": "^6.1.1",
   "vitest": "^4.1.8"
  },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,7 @@
+import resolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import generatePackageJson from "rollup-plugin-generate-package-json";
+import dts from "unplugin-dts/rollup";
 
 const external = [
  "@nestjs/common",
@@ -12,8 +14,6 @@ const external = [
  "@elsikora/nestjs-crud-automator",
  "dotenv/config",
 ];
-import resolve from "@rollup/plugin-node-resolve";
-import dtsPathAlias from "rollup-plugin-dts-path-alias";
 
 export default [
  {
@@ -37,13 +37,16 @@ export default [
    resolve({
     include: ["node_modules/tslib/**"],
    }),
-   dtsPathAlias(),
    typescript({
-    declaration: true,
-    declarationDir: "dist/esm",
+    declaration: false,
     outDir: "dist/esm",
     sourceMap: true,
     tsconfig: "./tsconfig.build.json",
+   }),
+   dts({
+    entryRoot: "src",
+    outDirs: ["dist/esm", "dist/cjs"],
+    tsconfigPath: "./tsconfig.build.json",
    }),
    generatePackageJson({
     baseContents: { type: "module" },
@@ -75,13 +78,11 @@ export default [
    }),
 
    typescript({
-    declaration: true,
-    declarationDir: "dist/cjs",
+    declaration: false,
     outDir: "dist/cjs",
     sourceMap: true,
     tsconfig: "./tsconfig.build.json",
    }),
-   dtsPathAlias(),
    generatePackageJson({
     baseContents: { type: "commonjs" },
     outputFolder: "dist/cjs",


### PR DESCRIPTION
## Summary
- Replaces `rollup-plugin-dts-path-alias` with `unplugin-dts/rollup`.
- Aligns declaration generation with `@elsikora/nestjs-crud-automator` by emitting DTS to both `dist/esm` and `dist/cjs` from the ESM build.
- Fixes published declaration imports so they point to existing `dist` paths instead of leaking `src` paths.

## Test plan
- `npm run lint`
- `npm run lint:types`
- `npm run build`
- `npm run test:unit`
- ESM/CJS runtime import checks
- `rg` check for `src`, `@shared`, and `@modules` leaks in `dist/**/*.d.ts`