### PR TITLE
feat(config): support temporal column type

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ import { CrudConfigModule, TOKEN_CONSTANT } from "@elsikora/nestjs-crud-config";
    // Entity customization
    entityOptions: {
     tablePrefix: "app_",
+    timestampColumnType: "timestamptz", // PostgreSQL; defaults to "timestamp"
     configSection: {
      tableName: "config_sections",
      maxNameLength: 128,
@@ -316,6 +317,7 @@ import { CrudConfigModule } from "@elsikora/nestjs-crud-config";
     },
     entityOptions: {
      tablePrefix: "app_",
+     timestampColumnType: "timestamptz", // Must be static for dynamic entities
      configSection: {
       tableName: "config_sections",
       maxNameLength: 128,
@@ -338,7 +340,7 @@ export class AppModule {}
 **Important:** The `staticOptions` property contains configuration that must be known at module compilation time:
 
 - `controllersOptions` - REST API controller configuration
-- `entityOptions` - Database entity customization (table names, field lengths)
+- `entityOptions` - Database entity customization (table names, field lengths, timestamp type)
 - `migrationEntityOptions` - Migration tracking table configuration
 
 ## 🚀 Migration System
@@ -990,6 +992,7 @@ The module provides extensive customization options:
 CrudConfigModule.register({
  entityOptions: {
   tablePrefix: "myapp_",
+  timestampColumnType: "timestamptz",
   configSection: {
    tableName: "configuration_sections",
    maxNameLength: 256,
@@ -1005,6 +1008,8 @@ CrudConfigModule.register({
  },
 });
 ```
+
+`timestampColumnType` applies to all nine temporal columns in the section, data, and migration entities. It defaults to `"timestamp"`; choose a TypeORM `ColumnType` supported by your database driver, such as `"timestamptz"` for PostgreSQL or `"datetime"` for SQL.js/SQLite. Changing it for an existing database still requires the corresponding schema migration.
 
 ### What happens if the database is unavailable?
 

--- a/docs/api-reference/interfaces/crud-config-entity-options/page.mdx
+++ b/docs/api-reference/interfaces/crud-config-entity-options/page.mdx
@@ -2,7 +2,7 @@ import { generateDefinition, TSDoc } from "nextra/tsdoc";
 
 # `ICrudConfigEntityOptions`
 
-Entity customization options (table names, field lengths, and table prefix).
+Entity customization options (table names, field lengths, table prefix, and the common TypeORM timestamp column type).
 
 _Defined in: `src/shared/interface/config/entity/options.interface.ts`_
 

--- a/docs/core-concepts/dynamic-entities/page.mdx
+++ b/docs/core-concepts/dynamic-entities/page.mdx
@@ -16,9 +16,19 @@ These entities are exported via tokens so you can plug them into `TypeOrmModule.
 
 ## Entity customization
 
-You can customize table names and column lengths via `entityOptions`.
+You can customize table names, column lengths, and the common temporal column type via `entityOptions`:
 
-In async registration, provide entity customization via `staticOptions.entityOptions` (and `staticOptions.migrationEntityOptions` for migration tracking table) so controllers and providers use the same entities.
+```typescript copy
+CrudConfigModule.register({
+ entityOptions: {
+  timestampColumnType: "timestamptz",
+ },
+});
+```
+
+`timestampColumnType` is passed to all nine temporal columns in `ConfigSection`, `ConfigData`, and `ConfigMigration`, including their TypeORM create/update date decorators. It defaults to `"timestamp"`. Select a TypeORM `ColumnType` supported by the configured driver, for example `"timestamptz"` with PostgreSQL or `"datetime"` with SQL.js/SQLite. Changing it for an existing database still requires the corresponding schema migration.
+
+In async registration, provide entity customization, including `timestampColumnType`, via `staticOptions.entityOptions` (and `staticOptions.migrationEntityOptions` for migration tracking table settings) so controllers and providers use the same entities.
 
 ## Default schema
 

--- a/src/modules/config/config.module.ts
+++ b/src/modules/config/config.module.ts
@@ -37,6 +37,9 @@ export class CrudConfigModule {
  public static register(options: IConfigOptions): DynamicModule {
   const prefix: string = options.entityOptions?.tablePrefix ?? "";
 
+  const timestampColumnType: NonNullable<ICrudConfigEntityOptions["timestampColumnType"]> =
+   options.entityOptions?.timestampColumnType ?? "timestamp";
+
   const sectionEntity: TDynamicEntity<IConfigSection> = createConfigSectionEntity({
    maxDescriptionLength:
     options.entityOptions?.configSection?.maxDescriptionLength ??
@@ -46,6 +49,7 @@ export class CrudConfigModule {
    tableName:
     prefix +
     (options.entityOptions?.configSection?.tableName ?? CONFIG_SECTION_CONSTANT.DEFAULT_TABLE_NAME),
+   timestampColumnType,
   });
 
   const dataEntity: TDynamicEntity<IConfigData> = createConfigDataEntity({
@@ -63,6 +67,7 @@ export class CrudConfigModule {
    tableName:
     prefix +
     (options.entityOptions?.configData?.tableName ?? CONFIG_DATA_CONSTANT.DEFAULT_TABLE_NAME),
+   timestampColumnType,
   });
 
   const migrationEntity: TDynamicEntity<IConfigMigration> = createConfigMigrationEntity({
@@ -70,6 +75,7 @@ export class CrudConfigModule {
     options.migrationOptions?.maxNameLength ?? CONFIG_MIGRATION_CONSTANT.MAX_NAME_LENGTH,
    tableName:
     prefix + (options.migrationOptions?.tableName ?? CONFIG_MIGRATION_CONSTANT.DEFAULT_TABLE_NAME),
+   timestampColumnType,
   });
 
   const propertiesProvider: Provider = {
@@ -239,6 +245,9 @@ export class CrudConfigModule {
    properties.staticOptions?.entityOptions;
   const prefix: string = staticEntityOptions?.tablePrefix ?? "";
 
+  const timestampColumnType: NonNullable<ICrudConfigEntityOptions["timestampColumnType"]> =
+   staticEntityOptions?.timestampColumnType ?? "timestamp";
+
   const sectionEntity: TDynamicEntity<IConfigSection> = createConfigSectionEntity({
    maxDescriptionLength:
     staticEntityOptions?.configSection?.maxDescriptionLength ??
@@ -248,6 +257,7 @@ export class CrudConfigModule {
    tableName:
     prefix +
     (staticEntityOptions?.configSection?.tableName ?? CONFIG_SECTION_CONSTANT.DEFAULT_TABLE_NAME),
+   timestampColumnType,
   });
 
   const dataEntity: TDynamicEntity<IConfigData> = createConfigDataEntity({
@@ -265,6 +275,7 @@ export class CrudConfigModule {
    tableName:
     prefix +
     (staticEntityOptions?.configData?.tableName ?? CONFIG_DATA_CONSTANT.DEFAULT_TABLE_NAME),
+   timestampColumnType,
   });
 
   const staticControllersOptions: IConfigControllersOptions | undefined =
@@ -294,6 +305,7 @@ export class CrudConfigModule {
     staticMigrationOptions?.maxNameLength ?? CONFIG_MIGRATION_CONSTANT.MAX_NAME_LENGTH,
    tableName:
     prefix + (staticMigrationOptions?.tableName ?? CONFIG_MIGRATION_CONSTANT.DEFAULT_TABLE_NAME),
+   timestampColumnType,
   });
 
   const providers: Array<Provider> = [

--- a/src/modules/config/data/entity/entity.ts
+++ b/src/modules/config/data/entity/entity.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @elsikora/typescript/naming-convention */
 import type { IConfigSection } from "@modules/config/section";
 import type { TDynamicEntity } from "@shared/type";
+import type { ColumnType } from "typeorm";
 
 import type { IConfigData } from "../interface";
 
@@ -24,6 +25,7 @@ import { CreateDateColumn, UpdateDateColumn } from "typeorm";
  * @param {number} options.maxNameLength - Maximum length for name field
  * @param {number} options.maxValueLength - Maximum length for value field
  * @param {string} options.tableName - Name of the database table
+ * @param {ColumnType} [options.timestampColumnType] - TypeORM type for timestamp fields; defaults to `timestamp`
  * @returns {TDynamicEntity} Dynamically created ConfigData entity class
  */
 export function createConfigDataEntity(options: {
@@ -33,13 +35,16 @@ export function createConfigDataEntity(options: {
  maxNameLength: number;
  maxValueLength: number;
  tableName: string;
+ timestampColumnType?: ColumnType;
 }): TDynamicEntity<IConfigData> {
+ const timestampColumnType: ColumnType = options.timestampColumnType ?? "timestamp";
+
  return createDynamicEntityClass({
   columns: {
    createdAt: {
     default: () => "CURRENT_TIMESTAMP",
     nullable: false,
-    type: "timestamp",
+    type: timestampColumnType,
    },
    description: {
     length: options.maxDescriptionLength,
@@ -64,7 +69,7 @@ export function createConfigDataEntity(options: {
    updatedAt: {
     default: () => "CURRENT_TIMESTAMP",
     nullable: false,
-    type: "timestamp",
+    type: timestampColumnType,
    },
    value: {
     length: options.maxValueLength,
@@ -74,7 +79,7 @@ export function createConfigDataEntity(options: {
   },
   decorators: {
    createdAt: [
-    CreateDateColumn(),
+    CreateDateColumn({ type: timestampColumnType }),
     ApiPropertyDescribe({
      format: EApiPropertyDateType.DATE_TIME,
      identifier: EApiPropertyDateIdentifier.CREATED_AT,
@@ -133,7 +138,7 @@ export function createConfigDataEntity(options: {
     }),
    ],
    updatedAt: [
-    UpdateDateColumn(),
+    UpdateDateColumn({ type: timestampColumnType }),
     ApiPropertyDescribe({
      format: EApiPropertyDateType.DATE_TIME,
      identifier: EApiPropertyDateIdentifier.UPDATED_AT,

--- a/src/modules/config/migration/entity/entity.ts
+++ b/src/modules/config/migration/entity/entity.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @elsikora/typescript/naming-convention */
 import type { TDynamicEntity } from "@shared/type";
+import type { ColumnType } from "typeorm";
 
 import type { IConfigMigration } from "../interface";
 
@@ -19,26 +20,30 @@ import { CreateDateColumn, UpdateDateColumn } from "typeorm";
  * @param {object} options - Configuration options for the entity
  * @param {number} options.maxNameLength - Maximum length for migration name field
  * @param {string} options.tableName - Name of the database table
+ * @param {ColumnType} [options.timestampColumnType] - TypeORM type for timestamp fields; defaults to `timestamp`
  * @returns {TDynamicEntity} Dynamically created ConfigMigration entity class
  */
 export function createConfigMigrationEntity(options: {
  maxNameLength: number;
  tableName: string;
+ timestampColumnType?: ColumnType;
 }): TDynamicEntity<IConfigMigration> {
+ const timestampColumnType: ColumnType = options.timestampColumnType ?? "timestamp";
+
  return createDynamicEntityClass({
   columns: {
    createdAt: {
     default: () => "CURRENT_TIMESTAMP",
     nullable: false,
-    type: "timestamp",
+    type: timestampColumnType,
    },
    executedAt: {
     nullable: true,
-    type: "timestamp",
+    type: timestampColumnType,
    },
    failedAt: {
     nullable: true,
-    type: "timestamp",
+    type: timestampColumnType,
    },
    name: {
     length: options.maxNameLength,
@@ -47,7 +52,7 @@ export function createConfigMigrationEntity(options: {
    },
    startedAt: {
     nullable: true,
-    type: "timestamp",
+    type: timestampColumnType,
    },
    status: {
     default: "PENDING",
@@ -58,12 +63,12 @@ export function createConfigMigrationEntity(options: {
    updatedAt: {
     default: () => "CURRENT_TIMESTAMP",
     nullable: false,
-    type: "timestamp",
+    type: timestampColumnType,
    },
   },
   decorators: {
    createdAt: [
-    CreateDateColumn(),
+    CreateDateColumn({ type: timestampColumnType }),
     ApiPropertyDescribe({
      format: EApiPropertyDateType.DATE_TIME,
      identifier: EApiPropertyDateIdentifier.CREATED_AT,
@@ -122,7 +127,7 @@ export function createConfigMigrationEntity(options: {
     }),
    ],
    updatedAt: [
-    UpdateDateColumn(),
+    UpdateDateColumn({ type: timestampColumnType }),
     ApiPropertyDescribe({
      format: EApiPropertyDateType.DATE_TIME,
      identifier: EApiPropertyDateIdentifier.UPDATED_AT,

--- a/src/modules/config/section/entity/entity.ts
+++ b/src/modules/config/section/entity/entity.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @elsikora/typescript/naming-convention */
 import type { TDynamicEntity } from "@shared/type";
+import type { ColumnType } from "typeorm";
 
 import type { IConfigSection } from "../interface";
 
@@ -20,19 +21,23 @@ import { CreateDateColumn, UpdateDateColumn } from "typeorm";
  * @param {number} options.maxDescriptionLength - Maximum length for description field
  * @param {number} options.maxNameLength - Maximum length for name field
  * @param {string} options.tableName - Name of the database table
+ * @param {ColumnType} [options.timestampColumnType] - TypeORM type for timestamp fields; defaults to `timestamp`
  * @returns {TDynamicEntity} Dynamically created ConfigSection entity class
  */
 export function createConfigSectionEntity(options: {
  maxDescriptionLength: number;
  maxNameLength: number;
  tableName: string;
+ timestampColumnType?: ColumnType;
 }): TDynamicEntity<IConfigSection> {
+ const timestampColumnType: ColumnType = options.timestampColumnType ?? "timestamp";
+
  return createDynamicEntityClass({
   columns: {
    createdAt: {
     default: () => "CURRENT_TIMESTAMP",
     nullable: false,
-    type: "timestamp",
+    type: timestampColumnType,
    },
    description: {
     length: options.maxDescriptionLength,
@@ -47,12 +52,12 @@ export function createConfigSectionEntity(options: {
    updatedAt: {
     default: () => "CURRENT_TIMESTAMP",
     nullable: false,
-    type: "timestamp",
+    type: timestampColumnType,
    },
   },
   decorators: {
    createdAt: [
-    CreateDateColumn(),
+    CreateDateColumn({ type: timestampColumnType }),
     ApiPropertyDescribe({
      format: EApiPropertyDateType.DATE_TIME,
      identifier: EApiPropertyDateIdentifier.CREATED_AT,
@@ -88,7 +93,7 @@ export function createConfigSectionEntity(options: {
     }),
    ],
    updatedAt: [
-    UpdateDateColumn(),
+    UpdateDateColumn({ type: timestampColumnType }),
     ApiPropertyDescribe({
      format: EApiPropertyDateType.DATE_TIME,
      identifier: EApiPropertyDateIdentifier.UPDATED_AT,

--- a/src/shared/interface/config/entity/options.interface.ts
+++ b/src/shared/interface/config/entity/options.interface.ts
@@ -1,3 +1,5 @@
+import type { ColumnType } from "typeorm";
+
 import type { IConfigEntityDataOptions, IConfigEntitySectionOptions } from "./";
 
 /**
@@ -19,4 +21,10 @@ export interface ICrudConfigEntityOptions {
   * Table name prefix for all entities
   */
  tablePrefix?: string;
+
+ /**
+  * TypeORM column type used by all ConfigSection, ConfigData, and ConfigMigration timestamp fields.
+  * Defaults to `timestamp`.
+  */
+ timestampColumnType?: ColumnType;
 }

--- a/test/e2e/timestamp-column-type.e2e.test.ts
+++ b/test/e2e/timestamp-column-type.e2e.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { DataSource } from "typeorm";
+
+import { createConfigDataEntity, createConfigSectionEntity } from "../../dist/esm/index";
+
+describe("dynamic entity timestamp column type", () => {
+ let dataSource: DataSource | undefined;
+
+ afterEach(async () => {
+  if (dataSource?.isInitialized) await dataSource.destroy();
+ });
+
+ it("creates and persists SQL.js entities with datetime timestamp columns", async () => {
+  const ConfigSectionEntity = createConfigSectionEntity({
+   maxDescriptionLength: 512,
+   maxNameLength: 128,
+   tableName: "datetime_config_section",
+   timestampColumnType: "datetime",
+  });
+  const ConfigDataEntity = createConfigDataEntity({
+   configSectionEntity: ConfigSectionEntity,
+   maxDescriptionLength: 512,
+   maxEnvironmentLength: 64,
+   maxNameLength: 128,
+   maxValueLength: 8192,
+   tableName: "datetime_config_data",
+   timestampColumnType: "datetime",
+  });
+
+  dataSource = new DataSource({
+   entities: [ConfigSectionEntity, ConfigDataEntity],
+   logging: false,
+   synchronize: true,
+   type: "sqljs",
+  });
+  await dataSource.initialize();
+
+  const sectionColumns = (await dataSource.query(
+   'PRAGMA table_info("datetime_config_section")',
+  )) as Array<{ name: string; type: string }>;
+  const dataColumns = (await dataSource.query(
+   'PRAGMA table_info("datetime_config_data")',
+  )) as Array<{ name: string; type: string }>;
+
+  for (const columns of [sectionColumns, dataColumns]) {
+   expect(
+    columns
+     .filter((column) => ["createdAt", "updatedAt"].includes(column.name))
+     .map((column) => column.type.toLowerCase()),
+   ).toEqual(["datetime", "datetime"]);
+  }
+
+  const section = await dataSource.getRepository(ConfigSectionEntity).save({ name: "runtime" });
+  const data = await dataSource.getRepository(ConfigDataEntity).save({
+   environment: "test",
+   isEncrypted: false,
+   name: "DATABASE_URL",
+   section,
+   value: "sqljs://memory",
+  });
+
+  expect(section.createdAt).toBeInstanceOf(Date);
+  expect(section.updatedAt).toBeInstanceOf(Date);
+  expect(data.createdAt).toBeInstanceOf(Date);
+  expect(data.updatedAt).toBeInstanceOf(Date);
+ });
+});

--- a/test/unit/modules/config/config.module.test.ts
+++ b/test/unit/modules/config/config.module.test.ts
@@ -7,6 +7,53 @@ import { TOKEN_CONSTANT } from "../../../../src/shared/constant";
 import type { IConfigOptions } from "../../../../src/shared/interface/config";
 import { Test } from "@nestjs/testing";
 import { getDataSourceToken } from "@nestjs/typeorm";
+import { getMetadataArgsStorage, type ColumnType } from "typeorm";
+
+function expectTemporalColumnTypes(
+ entity: Function,
+ propertyNames: string[],
+ expectedType: ColumnType,
+): void {
+ for (const propertyName of propertyNames) {
+  const columns = getMetadataArgsStorage().columns.filter(
+   (metadata) => metadata.target === entity && metadata.propertyName === propertyName,
+  );
+
+  expect(columns.length).toBeGreaterThan(0);
+  expect(columns.every((column) => column.options.type === expectedType)).toBe(true);
+ }
+}
+
+function getEntityProvider(dynamicModule: DynamicModule, token: symbol): Function {
+ const provider = dynamicModule.providers?.find(
+  (candidate: any) => candidate.provide === token,
+ ) as any;
+
+ expect(provider?.useValue).toBeDefined();
+
+ return provider.useValue as Function;
+}
+
+function expectAllEntityTimestampTypes(
+ dynamicModule: DynamicModule,
+ expectedType: ColumnType,
+): void {
+ expectTemporalColumnTypes(
+  getEntityProvider(dynamicModule, TOKEN_CONSTANT.CONFIG_SECTION_ENTITY),
+  ["createdAt", "updatedAt"],
+  expectedType,
+ );
+ expectTemporalColumnTypes(
+  getEntityProvider(dynamicModule, TOKEN_CONSTANT.CONFIG_DATA_ENTITY),
+  ["createdAt", "updatedAt"],
+  expectedType,
+ );
+ expectTemporalColumnTypes(
+  getEntityProvider(dynamicModule, TOKEN_CONSTANT.CONFIG_MIGRATION_ENTITY),
+  ["createdAt", "executedAt", "failedAt", "startedAt", "updatedAt"],
+  expectedType,
+ );
+}
 
 describe("CrudConfigModule", () => {
  beforeEach(() => {
@@ -81,6 +128,14 @@ describe("CrudConfigModule", () => {
 
    expect(configOptionsProvider).toBeDefined();
    expect(configOptionsProvider?.useValue).toEqual(options);
+  });
+
+  it("should propagate the common timestamp column type to all entities", () => {
+   const dynamicModule = CrudConfigModule.register({
+    entityOptions: { timestampColumnType: "timestamptz" },
+   });
+
+   expectAllEntityTimestampTypes(dynamicModule, "timestamptz");
   });
 
   it("should register module with cache enabled", () => {
@@ -308,6 +363,17 @@ describe("CrudConfigModule", () => {
 
    expect(migrationEntityProvider).toBeDefined();
    expect(migrationEntityProvider?.useValue).toBeDefined();
+  });
+
+  it("should propagate the static timestamp column type to all async entities", () => {
+   const dynamicModule = CrudConfigModule.registerAsync({
+    staticOptions: {
+     entityOptions: { timestampColumnType: "datetime" },
+    },
+    useFactory: () => ({ environment: "test" }),
+   });
+
+   expectAllEntityTimestampTypes(dynamicModule, "datetime");
   });
  });
 

--- a/test/unit/modules/config/data/entity/entity.test.ts
+++ b/test/unit/modules/config/data/entity/entity.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { createConfigDataEntity } from "../../../../../../src/modules/config/data/entity";
 import { CONFIG_DATA_CONSTANT } from "../../../../../../src/shared/constant";
-import { getMetadataArgsStorage } from "typeorm";
+import { getMetadataArgsStorage, type ColumnType } from "typeorm";
+
+function expectTimestampMetadata(entity: Function, expectedType: ColumnType): void {
+ for (const propertyName of ["createdAt", "updatedAt"]) {
+  const columns = getMetadataArgsStorage().columns.filter(
+   (metadata) => metadata.target === entity && metadata.propertyName === propertyName,
+  );
+
+  expect(columns).toHaveLength(2);
+  expect(columns.map((column) => column.options.type)).toEqual([expectedType, expectedType]);
+ }
+}
 
 describe("createConfigDataEntity", () => {
  it("should create a ConfigData entity with default settings", () => {
@@ -21,7 +32,23 @@ describe("createConfigDataEntity", () => {
   const instance = new ConfigDataEntity();
   expect(instance).toBeDefined();
   expect(instance.constructor.name).toBe("ConfigData");
+  expectTimestampMetadata(ConfigDataEntity, "timestamp");
   // Properties are defined via decorators at runtime
+ });
+
+ it("should use a custom timestamp column type for columns and date decorators", () => {
+  const mockSectionEntity = class ConfigSection {};
+  const ConfigDataEntity = createConfigDataEntity({
+   configSectionEntity: mockSectionEntity as any,
+   maxDescriptionLength: CONFIG_DATA_CONSTANT.MAX_DESCRIPTION_LENGTH,
+   maxEnvironmentLength: CONFIG_DATA_CONSTANT.MAX_ENVIRONMENT_LENGTH,
+   maxNameLength: CONFIG_DATA_CONSTANT.MAX_NAME_LENGTH,
+   maxValueLength: CONFIG_DATA_CONSTANT.MAX_VALUE_LENGTH,
+   tableName: CONFIG_DATA_CONSTANT.DEFAULT_TABLE_NAME,
+   timestampColumnType: "datetime",
+  });
+
+  expectTimestampMetadata(ConfigDataEntity, "datetime");
  });
 
  it("should create entity with custom table name", () => {

--- a/test/unit/modules/config/migration/entity/entity.test.ts
+++ b/test/unit/modules/config/migration/entity/entity.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createConfigMigrationEntity } from "../../../../../../src/modules/config/migration/entity";
+import { CONFIG_MIGRATION_CONSTANT } from "../../../../../../src/shared/constant";
+import { getMetadataArgsStorage, type ColumnType } from "typeorm";
+
+const TEMPORAL_COLUMN_DECORATOR_COUNTS: Record<string, number> = {
+ createdAt: 2,
+ executedAt: 1,
+ failedAt: 1,
+ startedAt: 1,
+ updatedAt: 2,
+};
+
+function expectTimestampMetadata(entity: Function, expectedType: ColumnType): void {
+ for (const [propertyName, expectedCount] of Object.entries(TEMPORAL_COLUMN_DECORATOR_COUNTS)) {
+  const columns = getMetadataArgsStorage().columns.filter(
+   (metadata) => metadata.target === entity && metadata.propertyName === propertyName,
+  );
+
+  expect(columns).toHaveLength(expectedCount);
+  expect(columns.every((column) => column.options.type === expectedType)).toBe(true);
+ }
+}
+
+describe("createConfigMigrationEntity", () => {
+ it("should default every temporal column and date decorator to timestamp", () => {
+  const ConfigMigrationEntity = createConfigMigrationEntity({
+   maxNameLength: CONFIG_MIGRATION_CONSTANT.MAX_NAME_LENGTH,
+   tableName: CONFIG_MIGRATION_CONSTANT.DEFAULT_TABLE_NAME,
+  });
+
+  expectTimestampMetadata(ConfigMigrationEntity, "timestamp");
+ });
+
+ it("should use a custom timestamp column type for every temporal column and date decorator", () => {
+  const ConfigMigrationEntity = createConfigMigrationEntity({
+   maxNameLength: CONFIG_MIGRATION_CONSTANT.MAX_NAME_LENGTH,
+   tableName: CONFIG_MIGRATION_CONSTANT.DEFAULT_TABLE_NAME,
+   timestampColumnType: "datetime",
+  });
+
+  expectTimestampMetadata(ConfigMigrationEntity, "datetime");
+ });
+});

--- a/test/unit/modules/config/section/entity/entity.test.ts
+++ b/test/unit/modules/config/section/entity/entity.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { createConfigSectionEntity } from "../../../../../../src/modules/config/section/entity";
 import { CONFIG_SECTION_CONSTANT } from "../../../../../../src/shared/constant";
+import { getMetadataArgsStorage, type ColumnType } from "typeorm";
+
+function expectTimestampMetadata(entity: Function, expectedType: ColumnType): void {
+ for (const propertyName of ["createdAt", "updatedAt"]) {
+  const columns = getMetadataArgsStorage().columns.filter(
+   (metadata) => metadata.target === entity && metadata.propertyName === propertyName,
+  );
+
+  expect(columns).toHaveLength(2);
+  expect(columns.map((column) => column.options.type)).toEqual([expectedType, expectedType]);
+ }
+}
 
 describe("createConfigSectionEntity", () => {
  it("should create a ConfigSection entity with default settings", () => {
@@ -16,7 +28,19 @@ describe("createConfigSectionEntity", () => {
   const instance = new ConfigSectionEntity();
   expect(instance).toBeDefined();
   expect(instance.constructor.name).toBe("ConfigSection");
+  expectTimestampMetadata(ConfigSectionEntity, "timestamp");
   // Properties are defined via decorators at runtime
+ });
+
+ it("should use a custom timestamp column type for columns and date decorators", () => {
+  const ConfigSectionEntity = createConfigSectionEntity({
+   maxDescriptionLength: CONFIG_SECTION_CONSTANT.MAX_DESCRIPTION_LENGTH,
+   maxNameLength: CONFIG_SECTION_CONSTANT.MAX_NAME_LENGTH,
+   tableName: CONFIG_SECTION_CONSTANT.DEFAULT_TABLE_NAME,
+   timestampColumnType: "datetime",
+  });
+
+  expectTimestampMetadata(ConfigSectionEntity, "datetime");
  });
 
  it("should create entity with custom table name", () => {


### PR DESCRIPTION
Summary:
- add optional entityOptions.timestampColumnType with backward-compatible timestamp default
- propagate the option through sync, async, and direct dynamic-entity factories
- cover all nine CrudConfig temporal fields with unit and SQL.js evidence
- document PostgreSQL timestamptz opt-in and consumer migration ownership

Verified locally:
- format and lint:all
- build and declaration-import check
- unit: 160/160
- e2e: 27/27
- npm pack dry-run
- independent audit: P0/P1/P2 none

Release boundary:
Merging into dev intentionally triggers semantic-release beta publication. Expected candidate: 3.1.0-dev.1 / tag v3.1.0-dev.1. Keep this PR unmerged until all feature-branch checks pass and publication is explicitly authorized.