### PR TITLE
fix(deps): pin compatible platform fastify

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "@nestjs/common": "^11.1.24",
   "@nestjs/core": "^11.1.24",
   "@nestjs/passport": "^11.0.5",
-  "@nestjs/platform-fastify": "^11.1.24",
+  "@nestjs/platform-fastify": "11.1.24",
   "@nestjs/schematics": "^11.1.0",
   "@nestjs/swagger": "11.4.2",
   "@nestjs/testing": "^11.1.24",


### PR DESCRIPTION
Pin `@nestjs/platform-fastify` to the already verified compatible version.

A newly published `11.1.29` changed its optional `@fastify/static` peer range and made the lockless release workflow fail dependency resolution against `@nestjs/swagger@11.4.2`. This one-line pin restores the dependency graph; no package runtime behavior changes.